### PR TITLE
[SP-139] fixed mySql error on CheckDuplicate

### DIFF
--- a/app/Database/DataContextExtensions.cs
+++ b/app/Database/DataContextExtensions.cs
@@ -1,0 +1,27 @@
+﻿using backend.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Reflection;
+
+namespace backend.Database
+{
+    public static class DataContextExtensions
+    {
+        public static IQueryable<T> LoadFields<T>(this DbSet<T> dataContext, string[]? fields = null)
+            where T : BaseModel
+        {
+            if (fields == null)
+            {
+                var reflectedFields = typeof(T).GetProperties().ToList();
+
+                reflectedFields.RemoveAll(field => !field.GetAccessors().Any(accessor => accessor.IsVirtual));
+                fields = reflectedFields.ConvertAll(tf => tf.Name).ToArray();
+            }
+
+            IQueryable<T> res = dataContext;
+            foreach (var field in fields)
+                res = res.Include(field);
+
+            return res;
+        }
+    }
+}

--- a/app/Helpers/EnumberableExtensions.cs
+++ b/app/Helpers/EnumberableExtensions.cs
@@ -1,15 +1,20 @@
 ﻿using System;
+using backend.Database;
 using backend.Exceptions;
+using backend.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace backend.Helpers
 {
 	public static class EnumberableExtensions
 	{
-		public static void CheckDuplicate<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, BasicException exception)
+		public static void CheckDuplicate<TSource>(this DbSet<TSource> source, Func<TSource, bool> predicate, BasicException exception, string[]? relatedFields = null)
+            where TSource : BaseModel
         {
             if (source != null)
             {
-                var elements = source.Where(predicate);
+                var loadedSource = source.LoadFields(relatedFields);
+                var elements = loadedSource.Where(predicate);
 
                 if (elements != null && elements.Any())
                     throw exception;

--- a/app/Models/Accounts/AccountModel.cs
+++ b/app/Models/Accounts/AccountModel.cs
@@ -3,7 +3,7 @@ using backend.Helpers;
 
 namespace backend.Models.Accounts
 {
-    public abstract class AccountModel
+    public abstract class AccountModel : BaseModel
     {
         public int Id { get; set; }
         public string Email { get; set; }

--- a/app/Models/BaseModel.cs
+++ b/app/Models/BaseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace backend.Models
+{
+    public abstract class BaseModel
+    {
+    }
+}

--- a/app/Models/SettingModel.cs
+++ b/app/Models/SettingModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace backend.Models
 {
-    public class SettingModel
+    public class SettingModel : BaseModel
     {
         public int Id { get; set; }
         public SettingType Type { get; set; }

--- a/app/Models/Vaccines/VaccineModel.cs
+++ b/app/Models/Vaccines/VaccineModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace backend.Models.Vaccines
 {
-    public class VaccineModel
+    public class VaccineModel : BaseModel
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/app/Models/Visits/VaccinationModel.cs
+++ b/app/Models/Visits/VaccinationModel.cs
@@ -3,7 +3,7 @@ using backend.Models.Vaccines;
 
 namespace backend.Models.Visits
 {
-    public class VaccinationModel
+    public class VaccinationModel : BaseModel
     {
         public int Id { get; set; }
         public virtual VaccineModel Vaccine { get; set; }

--- a/app/Models/Visits/VaccinationSlotModel.cs
+++ b/app/Models/Visits/VaccinationSlotModel.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace backend.Models.Visits
 {
-    public class VaccinationSlotModel
+    public class VaccinationSlotModel : BaseModel
     {
         public int Id { get; set; }
         public DateTime Date { get; set; }

--- a/app/Services/Doctor/VaccinationSlotService.cs
+++ b/app/Services/Doctor/VaccinationSlotService.cs
@@ -6,6 +6,7 @@ using backend.Exceptions;
 using backend.Helpers;
 using backend.Models.Accounts;
 using backend.Models.Visits;
+using Microsoft.EntityFrameworkCore;
 
 namespace backend.Services.Doctor
 {
@@ -39,11 +40,11 @@ namespace backend.Services.Doctor
 
             // Check for overlapping slots
             this.dataContext.VaccinationSlots
-                .CheckDuplicate(slot => 
-                    slot.Doctor.Id == doctor.Id 
-                    && slot.Date > date.AddMinutes(-slotMarginMins) 
+                .CheckDuplicate(slot =>
+                    slot.Doctor.Id == doctor.Id
+                    && slot.Date > date.AddMinutes(-slotMarginMins)
                     && slot.Date < date.AddMinutes(slotMarginMins),
-                    new ValidationException("Slots overlaps the existing slots.") 
+                    new ValidationException("Slots overlaps the existing slots.")
                 );
 
             // Add new slot to database

--- a/app/backend.csproj
+++ b/app/backend.csproj
@@ -28,4 +28,8 @@
   <ItemGroup>
     <None Include="Migrations" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Migrations\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
issue:
	during calls such as:
	```
	this.dataContext.VaccinationSlots
		.CheckDuplicate(slot =>
			slot.Doctor.Id == doctor.Id
			[...]
	);
	```
	there is another mySQL query under the hood to fetch the
	slot.doctor (unless the doctor object is fetched previously -
	e.g. the case when we were fetching the slots that were
	previously created by the same doctor that we are evaluating
	right now)

	Such calls should be executed as part of .Joins, not standalone!
	However, we are able to use Eager Loading processes (instead of
	Lazy Loading proxies - that are being used by us, to make up
	for complex .Join calls right now).

Eager Loading:
	before each chain of SQL queries such as .When(), there should
	be an .Include("property") call, which indicates a .Join query
	under the hood.

Workaround:
	Extension method for DbSet<BaseModel> (LoadFields) that eagerly
	loads related fields - the fields that are declared as virtual.
	We can also impose which specific fields to load using the
	optional parameter

Changes:
	BaseModel - abstract base class for all models to enable
	extension method implementation

Limitations:
	[WARNING] Models cannot have virtual properties OTHER THAN those that
	represent related fields

Signed-off-by: Brotholomew <bartoszek.blach@gmail.com>