### PR TITLE
[SP-139] Fix for lazyloading in response

### DIFF
--- a/app/Models/BaseModel.cs
+++ b/app/Models/BaseModel.cs
@@ -2,5 +2,14 @@
 {
     public abstract class BaseModel
     {
+        public T BaseObject<T>()
+            where T : BaseModel, new()
+        {
+            T ret = new T();
+            foreach(var property in ret.GetType().GetProperties())
+                property.SetValue(ret, property.GetValue(this));
+
+            return ret;
+        }
     }
 }

--- a/app/Services/Admin/AdminDoctorsService.cs
+++ b/app/Services/Admin/AdminDoctorsService.cs
@@ -95,7 +95,7 @@ namespace backend.Services.Admin
             this.dataContext.Doctors.Update(doctor);
             this.dataContext.SaveChanges();
 
-            return doctor;
+            return doctor.BaseObject<DoctorModel>();
         }
 
         public async Task<DoctorResponse> ShowDoctor(int doctorId)

--- a/tests/Unit/Services/Admin/AdminDoctorsServiceTest.cs
+++ b/tests/Unit/Services/Admin/AdminDoctorsServiceTest.cs
@@ -150,7 +150,7 @@ namespace backend_tests.Unit.Services.Admin
             this.dataContextMock.Verify(dataContext => dataContext.SaveChanges(), Times.Once());
 
             Assert.Single(verifyList);
-            Assert.Contains(verifyList, (obj) => obj == rsp);
+            Assert.Contains(verifyList, (obj) => obj.Id == rsp.Id);
 
             Assert.Equal(firstName == null ? doctorOld?.FirstName : firstName, rsp.FirstName);
             Assert.Equal(lastName == null ? doctorOld?.LastName : lastName, rsp.LastName);


### PR DESCRIPTION
PROBLEM:
	when querying objects from DB (e.g.: using When()), EF will not
	return objects of those exact classes we expect but some newly
	defined classes that are derived from the expected ones
	they will contain new, unwanted by us, fields (such as lazyloader
	in our example)
	it is harmless unless we return those derived objects -> that
	will result in unwanted fields in the json response

SOLUTION:
	to all classes derived from BaseModel a method BaseObject is
	added which will recreate an object of a parent class with
	filled out corresponding fields. (If needed in the future, it
	may be broadened to other objects as well).
	Whenever returning an object in a response that was created by a
	DB query, please return its base equivalent

Signed-off-by: Brotholomew <bartoszek.blach@gmail.com>