### PR TITLE
[SP-148] Fix response in Show available vaccines request

### DIFF
--- a/app/Dto/Responses/Patient/Vaccination/ShowAvailableVaccinesResponse.cs
+++ b/app/Dto/Responses/Patient/Vaccination/ShowAvailableVaccinesResponse.cs
@@ -5,7 +5,7 @@ namespace backend.Dto.Responses.Patient.Vaccination
 {
 	public class ShowAvailableVaccinesResponse
 	{
-		public List<VaccineResponse> Vaccines;
+		public List<VaccineResponse> Vaccines { get; set; }
 
 		public ShowAvailableVaccinesResponse(List<VaccineModel> vaccines)
 		{

--- a/app/Postman/IO.postman_collection.json
+++ b/app/Postman/IO.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "af32573b-7e73-4383-a21f-60782ae7be97",
+		"_postman_id": "e692f27e-a3aa-45f0-b575-2d2510a1e886",
 		"name": "IO",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -68,6 +68,55 @@
 						},
 						{
 							"name": "Show list of available vaccines",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const schema = {",
+											"  \"type\": \"object\",",
+											"  \"properties\": {",
+											"    \"vaccines\": {",
+											"      \"type\": \"array\",",
+											"      \"items\":",
+											"        {",
+											"          \"type\": \"object\",",
+											"          \"properties\": {",
+											"            \"id\": {",
+											"              \"type\": \"integer\"",
+											"            },",
+											"            \"name\": {",
+											"              \"type\": \"string\"",
+											"            },",
+											"            \"disease\": {",
+											"              \"type\": \"string\"",
+											"            },",
+											"            \"requiredDoses\": {",
+											"              \"type\": \"integer\"",
+											"            }",
+											"          },",
+											"          \"required\": [",
+											"            \"id\",",
+											"            \"name\",",
+											"            \"disease\",",
+											"            \"requiredDoses\"",
+											"          ]",
+											"        },",
+											"    },",
+											"  },",
+											"  \"required\": [",
+											"    \"vaccines\"",
+											"  ]",
+											"}",
+											"",
+											"pm.test(\"Response structure is valid\", () => {",
+											"    pm.response.to.have.jsonSchema(schema);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
 							"request": {
 								"method": "GET",
 								"header": [],

--- a/app/Services/Patient/VaccinationService.cs
+++ b/app/Services/Patient/VaccinationService.cs
@@ -24,7 +24,7 @@ namespace backend.Services.Patient
             this.mailer = mailer;
         }
 
-        public async Task<List<VaccineResponse>> ShowAvailableVaccines(DiseaseEnum disease)
+        public async Task<ShowAvailableVaccinesResponse> ShowAvailableVaccines(DiseaseEnum disease)
         {
             // Find vaccines for given disese
             List<VaccineModel> vaccines = this.dataContext.Vaccines
@@ -32,7 +32,7 @@ namespace backend.Services.Patient
                                               .ToList();
 
             // Return list of vaccines
-            return vaccines.Select(vaccine => new VaccineResponse(vaccine)).ToList();
+            return new ShowAvailableVaccinesResponse(vaccines);
         }
 
         public async Task<List<AvailableSlotResponse>> GetAvailableVaccinationSlots()

--- a/tests/Unit/Services/Patient/VaccinationServiceTest.cs
+++ b/tests/Unit/Services/Patient/VaccinationServiceTest.cs
@@ -42,7 +42,7 @@ namespace backend_tests.Unit.Services.Patient
             var response = this.vaccinationServiceMock.ShowAvailableVaccines(DiseaseEnumAdapter.ToEnum(diseaseName));
             Assert.NotNull(response);
 
-            List<VaccineResponse> vaccines = new List<VaccineResponse>(response.Result);
+            List<VaccineResponse> vaccines = new List<VaccineResponse>(response.Result.Vaccines);
             Assert.Equal(vaccines.Select(vaccine => vaccine.Id).ToArray(), expectedIds);
         }
 


### PR DESCRIPTION
Fixed response in _Show available vaccines_ request. Due to workaround in [SP-24] returned list of vaccines was unnamed, which is inconsistent with API. 

Changed list in ShowAvailableVaccinesResponse from variable to property, which fixed the issue with returning response with named list.

Created test in Postman to validate structure of valid API response.

 