### PR TITLE
[SP-175] Get vaccination slots as a common endpoint

### DIFF
--- a/app/Controllers/CommonVaccinationController.cs
+++ b/app/Controllers/CommonVaccinationController.cs
@@ -1,0 +1,25 @@
+﻿using backend.Helpers;
+using backend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace backend.Controllers
+{
+    [ApiController]
+    public class CommonVaccinationController : ControllerBase
+    {
+        private readonly CommonVaccinationService vaccinationService;
+
+        public CommonVaccinationController(CommonVaccinationService vaccinationService)
+        {
+            this.vaccinationService = vaccinationService;
+        }
+
+        // GET vaccination-slots
+        [HttpGet("vaccination-slots")]
+        [Authorize]
+        public async Task<IActionResult> GetAvailableVaccinationSlots()
+        {
+            return Ok(await this.vaccinationService.GetAvailableVaccinationSlots());
+        }
+    }
+}

--- a/app/Controllers/Patient/VaccinationController.cs
+++ b/app/Controllers/Patient/VaccinationController.cs
@@ -26,14 +26,6 @@ namespace backend.Controllers.Patient
             return Ok(await this.vaccinationService.ShowAvailableVaccines(request));
         }
 
-        // GET patient/vaccination-slots
-        [HttpGet("vaccination-slots")]
-        [Authorize(AccountTypeEnum.Patient)]
-        public async Task<IActionResult> GetAvailableVaccinationSlots()
-        {
-            return Ok(await this.vaccinationService.GetAvailableVaccinationSlots());
-        }
-
         // PUT patient/vaccination-slots/:{vaccinationSlotId}
         [HttpPut("vaccination-slots/{vaccinationSlotId:int}")]
         [Authorize(AccountTypeEnum.Patient)]

--- a/app/Postman/IO.postman_collection.json
+++ b/app/Postman/IO.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e4df0364-9fe8-41ae-bea8-0cd3809d372e",
+		"_postman_id": "f31a64ac-6146-4d63-bd0a-b65c432fc9e4",
 		"name": "IO",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -134,24 +134,6 @@
 											"key": "disease",
 											"value": "COVID-19"
 										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Get available vaccination slots",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{IOHostURL}}/patient/vaccination-slots",
-									"host": [
-										"{{IOHostURL}}"
-									],
-									"path": [
-										"patient",
-										"vaccination-slots"
 									]
 								}
 							},
@@ -1792,6 +1774,23 @@
 							"response": []
 						}
 					]
+				},
+				{
+					"name": "Get available vaccination slots",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{IOHostURL}}/vaccination-slots",
+							"host": [
+								"{{IOHostURL}}"
+							],
+							"path": [
+								"vaccination-slots"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"auth": {

--- a/app/Postman/IO.postman_collection.json
+++ b/app/Postman/IO.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f31a64ac-6146-4d63-bd0a-b65c432fc9e4",
+		"_postman_id": "3c082f18-61fc-46de-b460-14dc06236365",
 		"name": "IO",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddScoped<BugService>();
 builder.Services.AddScoped<AdminDoctorsService>();
 builder.Services.AddScoped<PatientService>();
 builder.Services.AddScoped<VaccinationService>();
+builder.Services.AddScoped<CommonVaccinationService>();
 
 // Connect settings to sections in appsettings.json
 builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSettings"));

--- a/app/Services/CommonVaccinationService.cs
+++ b/app/Services/CommonVaccinationService.cs
@@ -1,0 +1,27 @@
+﻿using backend.Database;
+using backend.Models.Visits;
+using backend.Dto.Responses.Patient.Vaccination;
+
+namespace backend.Services
+{
+    public class CommonVaccinationService
+    {
+        private readonly DataContext dataContext;
+
+        public CommonVaccinationService(DataContext dataContext)
+        {
+            this.dataContext = dataContext;
+        }
+        public async Task<List<AvailableSlotResponse>> GetAvailableVaccinationSlots()
+        {
+            // Find available vaccination slots
+            List<VaccinationSlotModel> slots = this.dataContext.VaccinationSlots
+                                              .Where(slot => slot.Reserved == false &&
+                                                             slot.Date >= DateTime.Now)
+                                              .ToList();
+
+            // Return list of slots
+            return slots.Select(slot => new AvailableSlotResponse(slot)).ToList();
+        }
+    }
+}

--- a/app/Services/Patient/VaccinationService.cs
+++ b/app/Services/Patient/VaccinationService.cs
@@ -41,18 +41,6 @@ namespace backend.Services.Patient
             return new ShowAvailableVaccinesResponse(vaccines);
         }
 
-        public async Task<List<AvailableSlotResponse>> GetAvailableVaccinationSlots()
-        {
-            // Find available vaccination slots
-            List<VaccinationSlotModel> slots = this.dataContext.VaccinationSlots
-                                              .Where(slot => slot.Reserved == false &&
-                                                             slot.Date >= DateTime.Now)
-                                              .ToList();
-
-            // Return list of slots
-            return slots.Select(slot => new AvailableSlotResponse(slot)).ToList();
-        }
-
         public async Task<SuccessResponse> ReserveVaccinationSlot(PatientModel patient, int vaccinationSlotId, int vaccineId)
         {
             // Find matching vaccine

--- a/tests/Unit/Services/CommonVaccinationServiceTest.cs
+++ b/tests/Unit/Services/CommonVaccinationServiceTest.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using backend.Database;
+using backend.Dto.Requests.Patient;
+using backend.Dto.Responses.Common.Vaccination;
+using backend.Dto.Responses.Patient.Vaccination;
+using backend.Exceptions;
+using backend.Helpers;
+using backend.Models.Accounts;
+using backend.Models.Vaccines;
+using backend.Models.Visits;
+using backend.Services;
+using backend.Services.Patient;
+using backend_tests.Helpers;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Moq;
+using Xunit;
+
+namespace backend_tests.Unit.Services.Patient
+{
+    public class CommonVaccinationServiceTest
+    {
+        private Mock<DataContext> dataContextMock { get; set; }
+        private CommonVaccinationService commonVaccinationServiceMock { get; set; }
+
+        public CommonVaccinationServiceTest()
+        {
+            // Constructor is being executed before each test
+            this.dataContextMock = DbHelper.GetMockedDataContextWithAccounts();
+            this.commonVaccinationServiceMock = new CommonVaccinationService(this.dataContextMock.Object);
+        }
+
+        // Get available vaccination slot
+        [Fact]
+        public void TestGetAvailableVaccinationSlots()
+        {
+            var response = this.commonVaccinationServiceMock.GetAvailableVaccinationSlots();
+            Assert.NotNull(response);
+
+            List<AvailableSlotResponse> slots = new List<AvailableSlotResponse>(response.Result);
+            Assert.Equal(slots.Select(slot => slot.Id).ToArray(), this.dataContextMock.Object.VaccinationSlots.Where(slot => !slot.Reserved).Select(slot => slot.Id).ToArray());
+            Assert.Equal(slots.Select(slot => slot.Date).ToArray(), this.dataContextMock.Object.VaccinationSlots.Where(slot => !slot.Reserved).Select(slot => slot.Date.ToUniversalTime()).ToArray());
+        }
+    }
+}

--- a/tests/Unit/Services/Patient/VaccinationServiceTest.cs
+++ b/tests/Unit/Services/Patient/VaccinationServiceTest.cs
@@ -24,7 +24,6 @@ namespace backend_tests.Unit.Services.Patient
         private Mock<DataContext> dataContextMock { get; set; }
         private Mock<Mailer> mailerMock { get; set; }
         private VaccinationService vaccinationServiceMock { get; set; }
-        private CommonVaccinationService commonVaccinationServiceMock { get; set; }
         private PatientModel patientMock { get; set; }
 
         public VaccinationServiceTest()
@@ -40,7 +39,6 @@ namespace backend_tests.Unit.Services.Patient
             ));
 
             this.vaccinationServiceMock = new VaccinationService(this.dataContextMock.Object, this.mailerMock.Object);
-            this.commonVaccinationServiceMock = new CommonVaccinationService(this.dataContextMock.Object);
             this.patientMock = this.dataContextMock.Object.Patients.First();
         }
 
@@ -175,18 +173,6 @@ namespace backend_tests.Unit.Services.Patient
         public void TestReserveVaccinationSlotThrowExceptionForReservedSlot(int slotId, int vaccineId)
         {
             Assert.ThrowsAsync<ConflictException>(() => this.vaccinationServiceMock.ReserveVaccinationSlot(this.patientMock, slotId, vaccineId));
-        }
-
-        // Get available vaccination slot
-        [Fact]
-        public void TestGetAvailableVaccinationSlots()
-        {
-            var response = this.commonVaccinationServiceMock.GetAvailableVaccinationSlots();
-            Assert.NotNull(response);
-            
-            List<AvailableSlotResponse> slots = new List<AvailableSlotResponse>(response.Result);
-            Assert.Equal(slots.Select(slot => slot.Id).ToArray(), this.dataContextMock.Object.VaccinationSlots.Where(slot => !slot.Reserved).Select(slot => slot.Id).ToArray());
-            Assert.Equal(slots.Select(slot => slot.Date).ToArray(), this.dataContextMock.Object.VaccinationSlots.Where(slot => !slot.Reserved).Select(slot => slot.Date.ToUniversalTime()).ToArray());
         }
 
         // Cancel reservation

--- a/tests/Unit/Services/Patient/VaccinationServiceTest.cs
+++ b/tests/Unit/Services/Patient/VaccinationServiceTest.cs
@@ -10,6 +10,7 @@ using backend.Helpers;
 using backend.Models.Accounts;
 using backend.Models.Vaccines;
 using backend.Models.Visits;
+using backend.Services;
 using backend.Services.Patient;
 using backend_tests.Helpers;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -23,6 +24,7 @@ namespace backend_tests.Unit.Services.Patient
         private Mock<DataContext> dataContextMock { get; set; }
         private Mock<Mailer> mailerMock { get; set; }
         private VaccinationService vaccinationServiceMock { get; set; }
+        private CommonVaccinationService commonVaccinationServiceMock { get; set; }
         private PatientModel patientMock { get; set; }
 
         public VaccinationServiceTest()
@@ -38,6 +40,7 @@ namespace backend_tests.Unit.Services.Patient
             ));
 
             this.vaccinationServiceMock = new VaccinationService(this.dataContextMock.Object, this.mailerMock.Object);
+            this.commonVaccinationServiceMock = new CommonVaccinationService(this.dataContextMock.Object);
             this.patientMock = this.dataContextMock.Object.Patients.First();
         }
 
@@ -178,7 +181,7 @@ namespace backend_tests.Unit.Services.Patient
         [Fact]
         public void TestGetAvailableVaccinationSlots()
         {
-            var response = this.vaccinationServiceMock.GetAvailableVaccinationSlots();
+            var response = this.commonVaccinationServiceMock.GetAvailableVaccinationSlots();
             Assert.NotNull(response);
             
             List<AvailableSlotResponse> slots = new List<AvailableSlotResponse>(response.Result);


### PR DESCRIPTION
Moved "Get vaccination slot" request from _patient_ to _common_ endpoint.
Change is required due to [recent changes](https://battnik90.stoplight.io/docs/io/branches/main/b3A6NTQ5Mjk0ODU-get-available-vaccination-slots) to API design.

