### PR TITLE
[SP-191] Fix NullReferenceException in AvailableSlotResponse

### DIFF
--- a/app/Dto/Responses/Patient/Vaccination/VaccinationResponse.cs
+++ b/app/Dto/Responses/Patient/Vaccination/VaccinationResponse.cs
@@ -1,4 +1,5 @@
-﻿using backend.Dto.Responses.Common.Vaccination;
+﻿using System.Diagnostics;
+using backend.Dto.Responses.Common.Vaccination;
 using backend.Models.Accounts;
 using backend.Models.Visits;
 
@@ -17,7 +18,7 @@ namespace backend.Dto.Responses.Patient.Vaccination
 		{
 			this.Id = vaccination.Id;
 			this.Vaccine = new VaccineResponse(vaccination.Vaccine);
-            this.VaccinationSlot = new AvailableSlotResponse(vaccination.VaccinationSlot);
+			this.VaccinationSlot = new AvailableSlotResponse(vaccination.VaccinationSlot);
 			this.Status = vaccination.Status.ToString();
 			this.Patient = vaccination.Patient;
             this.Doctor = vaccination.Doctor;

--- a/app/Services/Patient/VaccinationService.cs
+++ b/app/Services/Patient/VaccinationService.cs
@@ -145,11 +145,6 @@ namespace backend.Services.Patient
 
             var paginatedVaccinations = PaginatedList<VaccinationModel>.Paginate(vaccinations, request.Page);
 
-            foreach (var vaccination in paginatedVaccinations)
-            {
-                Debug.WriteLine(vaccination.VaccinationSlot);
-            }
-            
             return new PaginatedResponse<VaccinationModel, List<VaccinationResponse>>(
                 paginatedVaccinations,
                 paginatedVaccinations.Select(vaccination => new VaccinationResponse(vaccination)).ToList()

--- a/app/Services/Patient/VaccinationService.cs
+++ b/app/Services/Patient/VaccinationService.cs
@@ -1,4 +1,5 @@
-﻿using backend.Helpers;
+﻿using System.Diagnostics;
+using backend.Helpers;
 using backend.Database;
 using backend.Dto.Requests.Patient;
 using backend.Dto.Responses;
@@ -115,9 +116,13 @@ namespace backend.Services.Patient
 
             if (!slot.Reserved)
                 throw new ConflictException("You cannot cancel not reserved vaccination slot");
-
-            slot.Reserved = false;
+            
             vaccinationForSlot.Status = StatusEnum.Canceled;
+
+            // Duplicate vaccination slot
+            VaccinationSlotModel newSlot = new VaccinationSlotModel { Date = slot.Date, Doctor = slot.Doctor, Reserved = false };
+            this.dataContext.Add(newSlot);
+            
             this.dataContext.SaveChanges();
 
             // Send email with confirmation
@@ -135,10 +140,16 @@ namespace backend.Services.Patient
             var vaccinations = this.dataContext
                 .Vaccinations
                 .Where(vaccination => vaccination.PatientId == patient.Id)
+                .Include(vaccination => vaccination.VaccinationSlot)
                 .OrderByDescending(vaccination => vaccination.Id);
 
             var paginatedVaccinations = PaginatedList<VaccinationModel>.Paginate(vaccinations, request.Page);
 
+            foreach (var vaccination in paginatedVaccinations)
+            {
+                Debug.WriteLine(vaccination.VaccinationSlot);
+            }
+            
             return new PaginatedResponse<VaccinationModel, List<VaccinationResponse>>(
                 paginatedVaccinations,
                 paginatedVaccinations.Select(vaccination => new VaccinationResponse(vaccination)).ToList()

--- a/tests/Unit/Services/Patient/VaccinationServiceTest.cs
+++ b/tests/Unit/Services/Patient/VaccinationServiceTest.cs
@@ -196,7 +196,9 @@ namespace backend_tests.Unit.Services.Patient
 
             await this.vaccinationServiceMock.CancelVaccinationSlot(this.patientMock, vaccination.VaccinationSlotId);
 
-            Assert.Equal(false, vaccination.VaccinationSlot?.Reserved);
+            this.dataContextMock.Verify(dataContext => dataContext.Add(It.IsAny<VaccinationSlotModel>()), Times.Once());
+            
+            Assert.Equal(true, vaccination.VaccinationSlot?.Reserved);
             Assert.Equal(StatusEnum.Canceled, vaccination.Status);
 
             this.mailerMock.Verify(mailer => mailer.SendEmailAsync(


### PR DESCRIPTION
Zrobiłem tak jak proponował Przemek. Po anulowaniu slotu tworze jego duplikat, który staje się wolny i na niego można przypisać nową wizytę. Próbowałem na początku obejść się bez tego ale niestety sie nie udało. NullReferenceException był spowodowany tym, że mieliśmy relację 1-1 miedzy Vaccination a VaccinationSlot więc jak dwa Vaccination miały ten sam VaccinationSlot, to w jednym Vaccination obiekt VaccinationSlot był nullem. Teraz jak jest duplikowanie VaccinationSlot to nie zmieniałem tej relacji i dalej jest 1-1