### PR TITLE
[SP-159] Confirm registration

### DIFF
--- a/app/Controllers/Patient/PatientController.cs
+++ b/app/Controllers/Patient/PatientController.cs
@@ -25,6 +25,13 @@ namespace backend.Controllers.Patient
         {
             return Ok(await this.patientService.Register(request));
         }
+        
+        // POST patient/registration/confirm
+        [HttpPost("registration/confirm")]
+        public async Task<IActionResult> ConfirmRegistration([FromBody] ConfirmRegistrationRequest request)
+        {
+            return Ok(await this.patientService.ConfirmRegistration(request));
+        }
 
         // PUT patient/account
         [HttpPut("account")]

--- a/app/Database/Seeder.cs
+++ b/app/Database/Seeder.cs
@@ -54,7 +54,8 @@ namespace backend.Database
                     LastName = "Patient",
                     Password = this.securePasswordHasher.Hash("password"),
                     Pesel = "22222222222",
-                    AddressId = 1
+                    AddressId = 1,
+                    VerificationToken = null
                 }
             );
 

--- a/app/Dto/Requests/Patient/ConfirmRegistrationRequest.cs
+++ b/app/Dto/Requests/Patient/ConfirmRegistrationRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace backend.Dto.Requests.Patient
+{
+    [ExcludeFromCodeCoverage]
+    public class ConfirmRegistrationRequest
+    {
+        public string Token { get; set; }
+    }
+}
+

--- a/app/Exceptions/UnauthorizedException.cs
+++ b/app/Exceptions/UnauthorizedException.cs
@@ -6,10 +6,13 @@ namespace backend.Exceptions
     [ExcludeFromCodeCoverage]
     public class UnauthorizedException : BasicException
     {
+        public UnauthorizedException(string message) : base(message) { }
+        public UnauthorizedException() : base("Invalid credentials") { }
+        
         public override ErrorResponse Render(HttpResponse response)
         {
             response.StatusCode = StatusCodes.Status401Unauthorized;
-            return new ErrorResponse("Invalid credentials");
+            return new ErrorResponse(this.Message);
         }
     }
 }

--- a/app/Helpers/FrontendUrlsSettings.cs
+++ b/app/Helpers/FrontendUrlsSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace backend.Helpers
+{
+    public class FrontendUrlsSettings
+    {
+        public string ConfirmRegistration { get; set; }
+    }
+}

--- a/app/Helpers/Program.cs
+++ b/app/Helpers/Program.cs
@@ -54,6 +54,7 @@ public class ProgramHelper
         builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("JwtSettings"));
         builder.Services.Configure<HasherSettings>(builder.Configuration.GetSection("HasherSettings"));
         builder.Services.Configure<MailSettings>(builder.Configuration.GetSection("MailSettings"));
+        builder.Services.Configure<FrontendUrlsSettings>(builder.Configuration.GetSection("FrontendUrls"));
 
         // Connect to MySQL database
         string connectionString = builder.Configuration.GetConnectionString("MySQLConnection").ToString();

--- a/app/Models/Accounts/PatientModel.cs
+++ b/app/Models/Accounts/PatientModel.cs
@@ -7,8 +7,8 @@ namespace backend.Models.Accounts
     public class PatientModel : AccountModel
     {
         public string Pesel { get; set; }
+        public string? VerificationToken { get; set; }
         public virtual AddressModel Address { get; set; }
-
         // seeder purposes
         [JsonIgnore]
         public int AddressId { get; set; }

--- a/app/Postman/IO.postman_collection.json
+++ b/app/Postman/IO.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e340bff3-81d1-46cd-872f-030d4c0a3ccb",
+		"_postman_id": "275a598b-3ce4-4144-abb2-d152e7e64e6f",
 		"name": "IO",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -560,6 +560,34 @@
 								"vaccinations",
 								"6",
 								"certificate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Confirm email",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"token\": \"be7d9bc8-50db-4d7f-933c-78e854185e63\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{IOHostURL}}/patient/registration/confirm",
+							"host": [
+								"{{IOHostURL}}"
+							],
+							"path": [
+								"patient",
+								"registration",
+								"confirm"
 							]
 						}
 					},

--- a/app/Services/AuthService.cs
+++ b/app/Services/AuthService.cs
@@ -25,9 +25,7 @@ namespace backend.Services
         {
             var user = this.GetDataContextDbSet().SingleOrDefault(user => user.Email == request.Email);
 
-            // Return null if user not found or password is invalid
-            if (user == null || !this.securePasswordHasher.Verify(request.Password, user.Password))
-                throw new UnauthorizedException();
+            this.Validate(user, request.Password);
 
             // Authentication successful so generate jwt token
             var token = this.jwtGenerator.GenerateJwtToken(user.Id, user.GetEnum());
@@ -35,6 +33,13 @@ namespace backend.Services
             return this.GetResponse(token, user);
         }
 
+        protected virtual void Validate(AccountModel? user, string password)
+        {
+            // Return null if user not found or password is invalid
+            if (user == null || !this.securePasswordHasher.Verify(password, user.Password))
+                throw new UnauthorizedException();
+        }
+        
         protected abstract DbSet<T> GetDataContextDbSet();
 
         protected abstract AuthenticateResponse GetResponse(string token, T model);

--- a/app/Services/Patient/PatientAuthService.cs
+++ b/app/Services/Patient/PatientAuthService.cs
@@ -1,6 +1,7 @@
 ﻿using backend.Helpers;
 using backend.Database;
 using backend.Dto.Responses.Patient;
+using backend.Exceptions;
 using backend.Models.Accounts;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,6 +21,14 @@ namespace backend.Services.Patient
         {
             this.dataContext.Entry(model)?.Reference("Address")?.Load();
             return new AuthenticateResponse(token, model);
+        }
+
+        protected override void Validate(AccountModel? user, string password)
+        {
+            base.Validate(user, password);
+            
+            if (user != null && ((PatientModel)user).VerificationToken != null)
+                throw new UnauthorizedException("Please verify your email first");
         }
     }
 }

--- a/app/Services/Patient/PatientService.cs
+++ b/app/Services/Patient/PatientService.cs
@@ -1,5 +1,6 @@
 ﻿using backend.Database;
 using backend.Dto.Requests.Patient;
+using backend.Dto.Responses;
 using backend.Dto.Responses.Patient;
 using backend.Exceptions;
 using backend.Helpers;
@@ -12,6 +13,7 @@ namespace backend.Services.Patient
 	{
         private readonly DataContext dataContext;
         private readonly SecurePasswordHasher securePasswordHasher;
+        private readonly Mailer mailer;
 
         // Exposed for UTs
         public void ValidatePatient(string? email = null, string? pesel = null)
@@ -35,10 +37,11 @@ namespace backend.Services.Patient
             }
         }
 
-        public PatientService(DataContext dataContext, SecurePasswordHasher securePasswordHasher)
+        public PatientService(DataContext dataContext, SecurePasswordHasher securePasswordHasher, Mailer mailer)
         {
             this.dataContext = dataContext;
             this.securePasswordHasher = securePasswordHasher;
+            this.mailer = mailer;
         }
 
         public async Task<PatientResponse> Register(PatientRegistrationRequest request)
@@ -55,6 +58,8 @@ namespace backend.Services.Patient
                 LocalNumber = request.Address.LocalNumber
             };
 
+            var verificationToken = Guid.NewGuid().ToString();
+            
             PatientModel patient = new PatientModel()
             {
                 FirstName = request.FirstName,
@@ -62,13 +67,33 @@ namespace backend.Services.Patient
                 Email = request.Email,
                 Password = this.securePasswordHasher.Hash(request.Password),
                 Address = address,
-                Pesel = request.Pesel
+                Pesel = request.Pesel,
+                VerificationToken = verificationToken
             };
 
             this.dataContext.Patients.Add(patient);
             this.dataContext.SaveChanges();
+            
+            _ = this.mailer.SendEmailAsync(
+                request.Email,
+                "Verify your email",
+                $"Your account has been created. Please click link below to verify your email address. <br> <a href='http://localhost:8000/confirmRegistration/{verificationToken}'>LINK</a>"
+            );
 
             return new PatientResponse(patient);
+        }
+
+        public async Task<SuccessResponse> ConfirmRegistration(ConfirmRegistrationRequest request)
+        {
+            var patient = this.dataContext.Patients
+                .FirstOrDefault(patient => patient.VerificationToken == request.Token);
+
+            if (patient == null) throw new UnauthorizedException();
+
+            patient.VerificationToken = null;
+            this.dataContext.SaveChanges();
+
+            return new SuccessResponse();
         }
 
         public async Task<PatientResponse> EditPatient(PatientModel patient, PatientRequest request)

--- a/app/Services/Patient/PatientService.cs
+++ b/app/Services/Patient/PatientService.cs
@@ -95,6 +95,7 @@ namespace backend.Services.Patient
             if (patient == null) throw new UnauthorizedException("Provided token is not valid");
 
             patient.VerificationToken = null;
+            this.dataContext.Update(patient);
             this.dataContext.SaveChanges();
 
             return new SuccessResponse();

--- a/app/appsettings.json
+++ b/app/appsettings.json
@@ -15,6 +15,9 @@
   "JwtSettings": {
     "SecretToken": "Uk48yu%P!T&dc%e5P@Qe"
   },
+  "FrontendUrls": {
+    "confirmRegistration": "http://localhost:8080/patient/registration/confirm/{token}"
+  },
   "MailSettings": {
     "Mail": "d03b34a83b723d",
     "DisplayName": "Punkt szczepien",

--- a/tests/Helpers/DbHelper.cs
+++ b/tests/Helpers/DbHelper.cs
@@ -54,6 +54,7 @@ namespace backend_tests.Helpers
                 Email = "john@patient.com",
                 Password = SecurePasswordHasherHelper.Hasher.Hash("password"),
                 Pesel = "22222222222",
+                VerificationToken = null,
                 Address = new AddressModel()
                 {
 
@@ -68,6 +69,7 @@ namespace backend_tests.Helpers
                 Email = "john2@patient.com",
                 Password = SecurePasswordHasherHelper.Hasher.Hash("password"),
                 Pesel = "83020545496",
+                VerificationToken = null,
                 Address = new AddressModel()
                 {
 

--- a/tests/Helpers/DbHelper.cs
+++ b/tests/Helpers/DbHelper.cs
@@ -75,10 +75,25 @@ namespace backend_tests.Helpers
 
                 }
             };
+            
+            var p3 = new PatientModel()
+            {
+                Id = 3,
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                Email = "john3@patient.com",
+                Password = SecurePasswordHasherHelper.Hasher.Hash("password"),
+                Pesel = "83020545496",
+                VerificationToken = Guid.NewGuid().ToString(),
+                Address = new AddressModel()
+                {
+
+                }
+            };
 
             var patients = new List<PatientModel>()
             {
-                p1, p2
+                p1, p2, p3
             };
 
             #endregion

--- a/tests/Unit/Services/Admin/AdminPatientsServiceTest.cs
+++ b/tests/Unit/Services/Admin/AdminPatientsServiceTest.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using backend.Controllers.Admin;
 using backend.Services.Patient;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace backend_tests.Admin
@@ -45,7 +46,12 @@ namespace backend_tests.Admin
             this.dataContextMock = DbHelper.GetMockedDataContextWithAccounts();
             this.securePasswordHasherMock = SecurePasswordHasherHelper.Hasher;
             this.adminPatientsService = new AdminPatientsService(this.dataContextMock.Object);
-            this.patientService = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock, this.mailerMock.Object);
+            this.patientService = new PatientService(
+                this.dataContextMock.Object, 
+                this.securePasswordHasherMock, 
+                this.mailerMock.Object,
+                Options.Create(new FrontendUrlsSettings() { ConfirmRegistration = "http://localhost/{token}"})
+            );
             this.adminPatientController = new AdminPatientController(this.patientService, this.adminPatientsService);
         }
 

--- a/tests/Unit/Services/Admin/AdminPatientsServiceTest.cs
+++ b/tests/Unit/Services/Admin/AdminPatientsServiceTest.cs
@@ -23,7 +23,8 @@ namespace backend_tests.Admin
         private readonly AdminPatientsService adminPatientsService;
         private readonly PatientService patientService;
         private readonly SecurePasswordHasher securePasswordHasherMock;
-        private readonly AdminPatientController adminPatientController ;
+        private readonly AdminPatientController adminPatientController;
+        private readonly Mock<Mailer> mailerMock;
 
         private DoctorModel? FindDoctor(int doctorId)
         {
@@ -32,11 +33,19 @@ namespace backend_tests.Admin
 
         public AdminPatientsTest()
         {
+            this.mailerMock = new Mock<Mailer>();
+            this.mailerMock.Setup(mailer => mailer.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                null
+            ));
+            
             // constructor is being executed before each test
             this.dataContextMock = DbHelper.GetMockedDataContextWithAccounts();
             this.securePasswordHasherMock = SecurePasswordHasherHelper.Hasher;
             this.adminPatientsService = new AdminPatientsService(this.dataContextMock.Object);
-            this.patientService = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock);
+            this.patientService = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock, this.mailerMock.Object);
             this.adminPatientController = new AdminPatientController(this.patientService, this.adminPatientsService);
         }
 

--- a/tests/Unit/Services/Patient/PatientAuthServiceTest.cs
+++ b/tests/Unit/Services/Patient/PatientAuthServiceTest.cs
@@ -37,6 +37,7 @@ namespace backend_tests.Patient
         [InlineData("john@patient1.com", "password")]
         [InlineData("john@doctor.com", "password")]
         [InlineData("john@admin.com", "password")]
+        [InlineData("john3@admin.com", "password")] // Not verified
         public async Task UtTestAuthenticationWithWrongCredentials(string email, string password)
         {
             await Assert.ThrowsAsync<UnauthorizedException>(

--- a/tests/Unit/Services/Patient/PatientServiceTest.cs
+++ b/tests/Unit/Services/Patient/PatientServiceTest.cs
@@ -112,6 +112,16 @@ namespace backend_tests.Patient
             Assert.Equal(input[9], rsp.Pesel);
             
             Assert.NotNull(added.VerificationToken);
+            
+            // Verify if mailer has been called with correct params
+            this.mailerMock.Verify(mailer => mailer.SendEmailAsync(
+                added.Email,
+                "Verify your email",
+                It.Is<string>(
+                    body => body.Contains(added.VerificationToken)
+                ),
+                null
+            ), Times.Once);
         }
 
         [Theory]

--- a/tests/Unit/Services/Patient/PatientServiceTest.cs
+++ b/tests/Unit/Services/Patient/PatientServiceTest.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using backend.Controllers.Patient;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace backend_tests.Patient
@@ -60,7 +61,12 @@ namespace backend_tests.Patient
             
             this.dataContextMock = DbHelper.GetMockedDataContextWithAccounts();
             this.securePasswordHasherMock = SecurePasswordHasherHelper.Hasher;
-            this.patientServiceMock = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock, this.mailerMock.Object);
+            this.patientServiceMock = new PatientService(
+                this.dataContextMock.Object, 
+                this.securePasswordHasherMock, 
+                this.mailerMock.Object,
+                Options.Create(new FrontendUrlsSettings() { ConfirmRegistration = "http://localhost/{token}"})
+            );
             this.patientController = new PatientController(this.patientServiceMock);
             this.patientController.ControllerContext.HttpContext = new DefaultHttpContext();
         }

--- a/tests/Unit/Services/Patient/PatientServiceTest.cs
+++ b/tests/Unit/Services/Patient/PatientServiceTest.cs
@@ -23,6 +23,7 @@ namespace backend_tests.Patient
         private readonly SecurePasswordHasher securePasswordHasherMock;
         private readonly PatientService patientServiceMock;
         private readonly PatientController patientController;
+        private readonly Mock<Mailer> mailerMock;
 
         private T TestInputParse<T,U>(params string?[] input) 
             where T : PatientRequest, new()
@@ -49,9 +50,17 @@ namespace backend_tests.Patient
 
         public PatientTest()
         {
+            this.mailerMock = new Mock<Mailer>();
+            this.mailerMock.Setup(mailer => mailer.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                null
+            ));
+            
             this.dataContextMock = DbHelper.GetMockedDataContextWithAccounts();
             this.securePasswordHasherMock = SecurePasswordHasherHelper.Hasher;
-            this.patientServiceMock = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock);
+            this.patientServiceMock = new PatientService(this.dataContextMock.Object, this.securePasswordHasherMock, this.mailerMock.Object);
             this.patientController = new PatientController(this.patientServiceMock);
             this.patientController.ControllerContext.HttpContext = new DefaultHttpContext();
         }


### PR DESCRIPTION
Zrobiłem potwierdzanie rejestracji przez maila:

- Do PatientModel dodałem pole VerificationToken, które podczas rejestracji przyjmuje wartość generowanego uuid i wysyłany jest mail do użytkownika z linkiem na front zawierającym ten token (linki na front są przechowywane w appsettings.jon)
- Bez zweryfikowanego emaila użytkownik nie może się zalogować
- Po kliknięciu w link w mailu użytkownik zostanie przekierowany na front (na razie tego nie mamy) i front wyślę POST /patient/registration/confirm z przekazanym tokenem i to pole zostanie znullowane -> użytkownik będzie mógł się zalogowac